### PR TITLE
SRT Fix

### DIFF
--- a/arithmetic/src/division/srt/srt16/SRT16.scala
+++ b/arithmetic/src/division/srt/srt16/SRT16.scala
@@ -44,10 +44,15 @@ class SRT16(
   val quotientMinusOne = RegEnable(quotientMinusOneNext, 0.U(n.W), enable)
   val counter = RegEnable(counterNext, 0.U(log2Ceil(n).W), enable)
 
+  val occupiedNext = Wire(Bool())
+  val occupied = RegNext(occupiedNext, false.B)
+  occupied := Mux(input.fire, true.B, Mux(isLastCycle, false.B, occupied))
+
   //  Datapath
+  //  according two adders
   isLastCycle := !counter.orR
-  output.valid := isLastCycle
-  input.ready := isLastCycle
+  output.valid := Mux(occupied, isLastCycle, false.B)
+  input.ready := !occupied
   enable := input.fire || !isLastCycle
 
   val remainderNoCorrect: UInt = partialReminderSum + partialReminderCarry

--- a/arithmetic/src/division/srt/srt4/SRT4.scala
+++ b/arithmetic/src/division/srt/srt4/SRT4.scala
@@ -51,11 +51,15 @@ class SRT4(
   val quotientMinusOne = RegEnable(quotientMinusOneNext, 0.U(n.W), enable)
   val counter = RegEnable(counterNext, 0.U(log2Ceil(n).W), enable)
 
+  val occupiedNext = Wire(Bool())
+  val occupied = RegNext(occupiedNext, false.B)
+  occupied := Mux(input.fire, true.B, Mux(isLastCycle, false.B, occupied))
+
   //  Datapath
   //  according two adders
   isLastCycle := !counter.orR
-  output.valid := isLastCycle
-  input.ready := isLastCycle
+  output.valid := Mux(occupied, isLastCycle, false.B)
+  input.ready := !occupied
   enable := input.fire || !isLastCycle
 
   val remainderNoCorrect: UInt = partialReminderSum + partialReminderCarry

--- a/arithmetic/src/division/srt/srt8/SRT8.scala
+++ b/arithmetic/src/division/srt/srt8/SRT8.scala
@@ -53,11 +53,15 @@ class SRT8(
   val quotientMinusOne = RegEnable(quotientMinusOneNext, 0.U(n.W), enable)
   val counter = RegEnable(counterNext, 0.U(log2Ceil(n).W), enable)
 
+  val occupiedNext = Wire(Bool())
+  val occupied = RegNext(occupiedNext, false.B)
+  occupied := Mux(input.fire, true.B, Mux(isLastCycle, false.B, occupied))
+
   //  Datapath
   //  according two adders
   isLastCycle := !counter.orR
-  output.valid := isLastCycle
-  input.ready := isLastCycle
+  output.valid := Mux(occupied, isLastCycle, false.B)
+  input.ready := !occupied
   enable := input.fire || !isLastCycle
 
   val remainderNoCorrect: UInt = partialReminderSum + partialReminderCarry


### PR DESCRIPTION
Now the SRT output valid signal keeps high in idle state. 
To keep it low, add state machine to record SRT working state. 