### PR TITLE
fix srt issue when dividend rightshift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ checkformat:
 	mill -i __.checkFormat 
 
 test:
-	mill -i arithmetic.tests
+	mill -i -j 0 arithmetic.tests

--- a/arithmetic/src/division/srt/SRT.scala
+++ b/arithmetic/src/division/srt/SRT.scala
@@ -42,20 +42,27 @@ class SRT(
 
   val input = IO(Flipped(DecoupledIO(new SRTInput(dividendWidth, dividerWidth, n))))
   val output = IO(ValidIO(new SRTOutput(dividerWidth, dividendWidth)))
+  val dividendAppend = IO(Input(UInt((radixLog2-1).W)))
+  val appendWidth = IO(Input(UInt(2.W)))
 
 //   select radix
   if (radixLog2 == 2) { // SRT4
     val srt = Module(new SRT4(dividendWidth, dividerWidth, n, radixLog2, a, dTruncateWidth, rTruncateWidth))
     srt.input <> input
     output <> srt.output
+    srt.dividendAppend := dividendAppend
   } else if (radixLog2 == 3) { // SRT8
     val srt = Module(new SRT8(dividendWidth, dividerWidth, n, radixLog2, a, dTruncateWidth, rTruncateWidth))
     srt.input <> input
     output <> srt.output
+    srt.dividendAppend := dividendAppend
+    srt.appendWidth := appendWidth
   } else if (radixLog2 == 4) { //SRT16
     val srt = Module(new SRT16(dividendWidth, dividerWidth, n, radixLog2 >> 1, a, dTruncateWidth, rTruncateWidth))
     srt.input <> input
     output <> srt.output
+    srt.dividendAppend := dividendAppend
+    srt.appendWidth := appendWidth
   }
 
 //  val srt = radixLog2 match {

--- a/arithmetic/src/division/srt/SRT.scala
+++ b/arithmetic/src/division/srt/SRT.scala
@@ -40,29 +40,22 @@ class SRT(
 //    case _       => println("this srt is not supported")
 //  }
 
-  val input = IO(Flipped(DecoupledIO(new SRTInput(dividendWidth, dividerWidth, n))))
+  val input = IO(Flipped(DecoupledIO(new SRTInput(dividendWidth, dividerWidth, n, radixLog2))))
   val output = IO(ValidIO(new SRTOutput(dividerWidth, dividendWidth)))
-  val dividendAppend = IO(Input(UInt((radixLog2-1).W)))
-  val appendWidth = IO(Input(UInt(2.W)))
 
 //   select radix
   if (radixLog2 == 2) { // SRT4
     val srt = Module(new SRT4(dividendWidth, dividerWidth, n, radixLog2, a, dTruncateWidth, rTruncateWidth))
     srt.input <> input
     output <> srt.output
-    srt.dividendAppend := dividendAppend
   } else if (radixLog2 == 3) { // SRT8
     val srt = Module(new SRT8(dividendWidth, dividerWidth, n, radixLog2, a, dTruncateWidth, rTruncateWidth))
     srt.input <> input
     output <> srt.output
-    srt.dividendAppend := dividendAppend
-    srt.appendWidth := appendWidth
   } else if (radixLog2 == 4) { //SRT16
     val srt = Module(new SRT16(dividendWidth, dividerWidth, n, radixLog2 >> 1, a, dTruncateWidth, rTruncateWidth))
     srt.input <> input
     output <> srt.output
-    srt.dividendAppend := dividendAppend
-    srt.appendWidth := appendWidth
   }
 
 //  val srt = radixLog2 match {

--- a/arithmetic/src/division/srt/SRTIO.scala
+++ b/arithmetic/src/division/srt/SRTIO.scala
@@ -3,10 +3,10 @@ package division.srt
 import chisel3._
 import chisel3.util.log2Ceil
 // SRTIO
-class SRTInput(dividendWidth: Int, dividerWidth: Int, n: Int) extends Bundle {
+class SRTInput(dividendWidth: Int, dividerWidth: Int, n: Int, radix2: Int) extends Bundle {
 
   /** r*residual[0] */
-  val dividend = UInt(dividendWidth.W) //.***********
+  val dividend = UInt((dividendWidth + radix2 - 1).W) //.***********
   val divider = UInt(dividerWidth.W) //.1**********
   val counter = UInt(log2Ceil(n).W) //the width of quotient.
 }

--- a/arithmetic/src/division/srt/SRTIO.scala
+++ b/arithmetic/src/division/srt/SRTIO.scala
@@ -4,6 +4,7 @@ import chisel3._
 import chisel3.util.log2Ceil
 // SRTIO
 class SRTInput(dividendWidth: Int, dividerWidth: Int, n: Int) extends Bundle {
+
   /** r*residual[0] */
   val dividend = UInt(dividendWidth.W) //.***********
   val divider = UInt(dividerWidth.W) //.1**********
@@ -21,7 +22,7 @@ class OTFInput(qWidth: Int, ohWidth: Int) extends Bundle {
   val quotientMinusOne = UInt(qWidth.W)
   val selectedQuotientOH = UInt(ohWidth.W)
 }
-/** if needcorrect*/
+
 class OTFOutput(qWidth: Int) extends Bundle {
   val quotient = UInt(qWidth.W)
   val quotientMinusOne = UInt(qWidth.W)
@@ -31,11 +32,9 @@ class OTFOutput(qWidth: Int) extends Bundle {
 class QDSInput(rWidth: Int, partialDividerWidth: Int) extends Bundle {
   val partialReminderCarry: UInt = UInt(rWidth.W)
   val partialReminderSum:   UInt = UInt(rWidth.W)
-  /** truncated divisor with the -1 bit truncated either
-    *
-    * todo: use origin truncated divisor
-    */
-  val partialDivider:       UInt = UInt(partialDividerWidth.W)
+
+  /** truncated divisor with the -1 bit truncated either */
+  val partialDivider: UInt = UInt(partialDividerWidth.W)
 }
 
 class QDSOutput(ohWidth: Int) extends Bundle {

--- a/arithmetic/src/division/srt/SRTIO.scala
+++ b/arithmetic/src/division/srt/SRTIO.scala
@@ -32,8 +32,7 @@ class OTFOutput(qWidth: Int) extends Bundle {
 class QDSInput(rWidth: Int, partialDividerWidth: Int) extends Bundle {
   val partialReminderCarry: UInt = UInt(rWidth.W)
   val partialReminderSum:   UInt = UInt(rWidth.W)
-
-  /** truncated divisor with the -1 bit truncated either */
+  /** truncated divisor without the most significant bit  */
   val partialDivider: UInt = UInt(partialDividerWidth.W)
 }
 

--- a/arithmetic/src/division/srt/SRTIO.scala
+++ b/arithmetic/src/division/srt/SRTIO.scala
@@ -4,6 +4,7 @@ import chisel3._
 import chisel3.util.log2Ceil
 // SRTIO
 class SRTInput(dividendWidth: Int, dividerWidth: Int, n: Int) extends Bundle {
+  /** r*residual[0] */
   val dividend = UInt(dividendWidth.W) //.***********
   val divider = UInt(dividerWidth.W) //.1**********
   val counter = UInt(log2Ceil(n).W) //the width of quotient.
@@ -20,7 +21,7 @@ class OTFInput(qWidth: Int, ohWidth: Int) extends Bundle {
   val quotientMinusOne = UInt(qWidth.W)
   val selectedQuotientOH = UInt(ohWidth.W)
 }
-
+/** if needcorrect*/
 class OTFOutput(qWidth: Int) extends Bundle {
   val quotient = UInt(qWidth.W)
   val quotientMinusOne = UInt(qWidth.W)
@@ -30,6 +31,10 @@ class OTFOutput(qWidth: Int) extends Bundle {
 class QDSInput(rWidth: Int, partialDividerWidth: Int) extends Bundle {
   val partialReminderCarry: UInt = UInt(rWidth.W)
   val partialReminderSum:   UInt = UInt(rWidth.W)
+  /** truncated divisor with the -1 bit truncated either
+    *
+    * todo: use origin truncated divisor
+    */
   val partialDivider:       UInt = UInt(partialDividerWidth.W)
 }
 

--- a/arithmetic/src/division/srt/SRTTable.scala
+++ b/arithmetic/src/division/srt/SRTTable.scala
@@ -14,6 +14,11 @@ import spire.math._
   * @param radix is the radix of SRT.
   *              It defined how many rounds can be calculate in one cycle.
   *              @note 5.2
+  * @param a digit set
+  * @param dTruncateWidth
+  * @param xTruncateWidth
+  * @param dMin
+  * @param dMax
   */
 case class SRTTable(
   radix:          Algebraic,

--- a/arithmetic/src/division/srt/srt16/SRT16.scala
+++ b/arithmetic/src/division/srt/srt16/SRT16.scala
@@ -28,7 +28,15 @@ class SRT16(
   // IO
   val input = IO(Flipped(DecoupledIO(new SRTInput(dividendWidth, dividerWidth, n))))
   val output = IO(ValidIO(new SRTOutput(dividerWidth, dividendWidth)))
-  val fixValue = IO(Input(UInt(fixWidth.W)))
+  val dividendAppend = IO(Input(UInt(fixWidth.W)))
+  val appendWidth = IO(Input(UInt(2.W)))
+
+  val appendValue = Wire(UInt(3.W))
+  appendValue := Mux(
+    appendWidth === 1.U,
+    Cat(dividendAppend(0), 0.U(2.W)),
+    Mux(appendWidth === 2.U, Cat(dividendAppend(1, 0), 0.U(1.W)), dividendAppend)
+  )
 
   val partialReminderCarryNext, partialReminderSumNext = Wire(UInt(wLen.W))
   val dividerNext = Wire(UInt(divisorWidthFix.W))
@@ -143,6 +151,6 @@ class SRT16(
   counterNext := Mux(input.fire, input.bits.counter, counter - 1.U)
   quotientNext := Mux(input.fire, 0.U, otf1(0))
   quotientMinusOneNext := Mux(input.fire, 0.U, otf1(1))
-  partialReminderSumNext := Mux(input.fire, Cat(input.bits.dividend, fixValue), csa1Out(1) << radixLog2)
+  partialReminderSumNext := Mux(input.fire, Cat(input.bits.dividend, appendValue), csa1Out(1) << radixLog2)
   partialReminderCarryNext := Mux(input.fire, 0.U, csa1Out(0) << radixLog2 + 1)
 }

--- a/arithmetic/src/division/srt/srt16/SRT16.scala
+++ b/arithmetic/src/division/srt/srt16/SRT16.scala
@@ -26,17 +26,8 @@ class SRT16(
   val rWidth:  Int = 1 + radixLog2 + rTruncateWidth
 
   // IO
-  val input = IO(Flipped(DecoupledIO(new SRTInput(dividendWidth, dividerWidth, n))))
+  val input = IO(Flipped(DecoupledIO(new SRTInput(dividendWidth, dividerWidth, n, 4))))
   val output = IO(ValidIO(new SRTOutput(dividerWidth, dividendWidth)))
-  val dividendAppend = IO(Input(UInt(fixWidth.W)))
-  val appendWidth = IO(Input(UInt(2.W)))
-
-  val appendValue = Wire(UInt(3.W))
-  appendValue := Mux(
-    appendWidth === 1.U,
-    Cat(dividendAppend(0), 0.U(2.W)),
-    Mux(appendWidth === 2.U, Cat(dividendAppend(1, 0), 0.U(1.W)), dividendAppend)
-  )
 
   val partialReminderCarryNext, partialReminderSumNext = Wire(UInt(wLen.W))
   val dividerNext = Wire(UInt(divisorWidthFix.W))
@@ -151,6 +142,6 @@ class SRT16(
   counterNext := Mux(input.fire, input.bits.counter, counter - 1.U)
   quotientNext := Mux(input.fire, 0.U, otf1(0))
   quotientMinusOneNext := Mux(input.fire, 0.U, otf1(1))
-  partialReminderSumNext := Mux(input.fire, Cat(input.bits.dividend, appendValue), csa1Out(1) << radixLog2)
+  partialReminderSumNext := Mux(input.fire, input.bits.dividend, csa1Out(1) << radixLog2)
   partialReminderCarryNext := Mux(input.fire, 0.U, csa1Out(0) << radixLog2 + 1)
 }

--- a/arithmetic/src/division/srt/srt16/SRT16.scala
+++ b/arithmetic/src/division/srt/srt16/SRT16.scala
@@ -1,9 +1,8 @@
 package division.srt.srt16
 
-import Chisel.Cat
 import division.srt._
 import chisel3._
-import chisel3.util.{log2Ceil, DecoupledIO, Fill, Mux1H, RegEnable, ValidIO}
+import chisel3.util._
 import utils.leftShift
 
 /** RSRT16 with Two SRT4 Overlapped Stages

--- a/arithmetic/src/division/srt/srt16/SRT16.scala
+++ b/arithmetic/src/division/srt/srt16/SRT16.scala
@@ -18,9 +18,9 @@ class SRT16(
   dTruncateWidth: Int = 4,
   rTruncateWidth: Int = 4)
     extends Module {
-  val fixWidth = 3
-  val divisorWidthFix = dividerWidth + fixWidth
-  val xLen:    Int = dividendWidth + radixLog2 + 1 + fixWidth
+  val guardBitWidth = 3
+  val divisorWidthFix = dividerWidth + guardBitWidth
+  val xLen:    Int = dividendWidth + radixLog2 + 1 + guardBitWidth
   val wLen:    Int = xLen + radixLog2
   val ohWidth: Int = 2 * a + 1
   val rWidth:  Int = 1 + radixLog2 + rTruncateWidth
@@ -61,7 +61,7 @@ class SRT16(
     partialReminderSum + partialReminderCarry + (divider << radixLog2)
   val needCorrect: Bool = remainderNoCorrect(wLen - 3).asBool
   // todo issue here
-  output.bits.reminder := Mux(needCorrect, remainderCorrect, remainderNoCorrect)(wLen - 4, radixLog2 + fixWidth)
+  output.bits.reminder := Mux(needCorrect, remainderCorrect, remainderNoCorrect)(wLen - 4, radixLog2 + guardBitWidth)
   output.bits.quotient := Mux(needCorrect, quotientMinusOne, quotient)
 
   // 5*CSA32  SRT16 <- SRT4 + SRT4*5 /SRT16 -> CSA53+CSA32
@@ -138,7 +138,7 @@ class SRT16(
   val otf0 = OTF(radixLog2, n, ohWidth)(quotient, quotientMinusOne, qdsOH0)
   val otf1 = OTF(radixLog2, n, ohWidth)(otf0(0), otf0(1), qdsOH1)
 
-  dividerNext := Mux(input.fire, Cat(input.bits.divider, 0.U(fixWidth.W)), divider)
+  dividerNext := Mux(input.fire, Cat(input.bits.divider, 0.U(guardBitWidth.W)), divider)
   counterNext := Mux(input.fire, input.bits.counter, counter - 1.U)
   quotientNext := Mux(input.fire, 0.U, otf1(0))
   quotientMinusOneNext := Mux(input.fire, 0.U, otf1(1))

--- a/arithmetic/src/division/srt/srt16/SRT16.scala
+++ b/arithmetic/src/division/srt/srt16/SRT16.scala
@@ -46,12 +46,12 @@ class SRT16(
 
   val occupiedNext = Wire(Bool())
   val occupied = RegNext(occupiedNext, false.B)
-  occupiedNext := Mux(input.fire, true.B, Mux(isLastCycle, false.B, occupied))
+  occupiedNext := input.fire || (!isLastCycle && occupied)
 
   //  Datapath
   //  according two adders
   isLastCycle := !counter.orR
-  output.valid := Mux(occupied, isLastCycle, false.B)
+  output.valid := occupied && isLastCycle
   input.ready := !occupied
   enable := input.fire || !isLastCycle
 

--- a/arithmetic/src/division/srt/srt16/SRT16.scala
+++ b/arithmetic/src/division/srt/srt16/SRT16.scala
@@ -19,7 +19,6 @@ class SRT16(
   rTruncateWidth: Int = 4)
     extends Module {
   val guardBitWidth = 3
-  val divisorWidthFix = dividerWidth + guardBitWidth
   val xLen:    Int = dividendWidth + radixLog2 + 1 + guardBitWidth
   val wLen:    Int = xLen + radixLog2
   val ohWidth: Int = 2 * a + 1
@@ -61,7 +60,7 @@ class SRT16(
   val remainderCorrect: UInt =
     partialReminderSum + partialReminderCarry + (divisorExtended << radixLog2)
   val needCorrect: Bool = remainderNoCorrect(wLen - 3).asBool
-  // todo issue here
+
   output.bits.reminder := Mux(needCorrect, remainderCorrect, remainderNoCorrect)(wLen - 4, radixLog2 + guardBitWidth)
   output.bits.quotient := Mux(needCorrect, quotientMinusOne, quotient)
 

--- a/arithmetic/src/division/srt/srt4/QDS.scala
+++ b/arithmetic/src/division/srt/srt4/QDS.scala
@@ -7,6 +7,14 @@ import chisel3.util.BitPat.bitPatToUInt
 import chisel3.util.experimental.decode.TruthTable
 import utils.{extend, sIntToBitPat}
 
+/** quotient divisor select
+  *
+  * @param rWidth y Truncate width
+  * @param ohWidth quotient Width
+  * @param partialDividerWidth equals to dTruncatedWidth - 1
+  * @param tables QDS table
+  *
+  */
 class QDS(rWidth: Int, ohWidth: Int, partialDividerWidth: Int, tables: Seq[Seq[Int]], a: Int) extends Module {
   // IO
   val input = IO(Input(new QDSInput(rWidth, partialDividerWidth)))
@@ -44,8 +52,11 @@ class QDS(rWidth: Int, ohWidth: Int, partialDividerWidth: Int, tables: Seq[Seq[I
 
   val columnSelect = input.partialDivider
   val adderWidth = rWidth + 1
+  /** 3 integer bits, 4 fractional bits*/
   val yTruncate: UInt = input.partialReminderCarry + input.partialReminderSum
+  /** the selection constant vector */
   val mkVec = selectRom(columnSelect)
+  /** add [[yTruncate]] with all mk, use decoder to find its location */
   val selectPoints = VecInit(mkVec.map { mk =>
     (extend(yTruncate, adderWidth).asUInt
       + extend(mk, adderWidth).asUInt).head(1)

--- a/arithmetic/src/division/srt/srt4/QDS.scala
+++ b/arithmetic/src/division/srt/srt4/QDS.scala
@@ -10,10 +10,9 @@ import utils.{extend, sIntToBitPat}
 /** quotient divisor select
   *
   * @param rWidth y Truncate width
-  * @param ohWidth quotient Width
+  * @param ohWidth quotient width
   * @param partialDividerWidth equals to dTruncatedWidth - 1
   * @param tables QDS table
-  *
   */
 class QDS(rWidth: Int, ohWidth: Int, partialDividerWidth: Int, tables: Seq[Seq[Int]], a: Int) extends Module {
   // IO
@@ -52,10 +51,13 @@ class QDS(rWidth: Int, ohWidth: Int, partialDividerWidth: Int, tables: Seq[Seq[I
 
   val columnSelect = input.partialDivider
   val adderWidth = rWidth + 1
-  /** 3 integer bits, 4 fractional bits*/
+
+  /** 3 integer bits, 4 fractional bits */
   val yTruncate: UInt = input.partialReminderCarry + input.partialReminderSum
+
   /** the selection constant vector */
   val mkVec = selectRom(columnSelect)
+
   /** add [[yTruncate]] with all mk, use decoder to find its location */
   val selectPoints = VecInit(mkVec.map { mk =>
     (extend(yTruncate, adderWidth).asUInt

--- a/arithmetic/src/division/srt/srt4/SRT4.scala
+++ b/arithmetic/src/division/srt/srt4/SRT4.scala
@@ -41,9 +41,8 @@ class SRT4(
   val xLen: Int = dividendWidth + radixLog2 + 1 + fixWidth
   val wLen: Int = xLen + radixLog2
   // IO
-  val input = IO(Flipped(DecoupledIO(new SRTInput(dividendWidth, dividerWidth, n))))
+  val input = IO(Flipped(DecoupledIO(new SRTInput(dividendWidth, dividerWidth, n, 2))))
   val output = IO(ValidIO(new SRTOutput(dividerWidth, dividendWidth)))
-  val dividendAppend = IO(Input(UInt(1.W)))
 
   //rW[j]
   val partialReminderCarryNext, partialReminderSumNext = Wire(UInt(wLen.W))
@@ -161,6 +160,6 @@ class SRT4(
   counterNext := Mux(input.fire, input.bits.counter, counter - 1.U)
   quotientNext := Mux(input.fire, 0.U, otf(0))
   quotientMinusOneNext := Mux(input.fire, 0.U, otf(1))
-  partialReminderSumNext := Mux(input.fire, Cat(input.bits.dividend, dividendAppend), csa(1) << radixLog2)
+  partialReminderSumNext := Mux(input.fire, input.bits.dividend, csa(1) << radixLog2)
   partialReminderCarryNext := Mux(input.fire, 0.U, csa(0) << 1 + radixLog2)
 }

--- a/arithmetic/src/division/srt/srt4/SRT4.scala
+++ b/arithmetic/src/division/srt/srt4/SRT4.scala
@@ -94,7 +94,6 @@ class SRT4(
     case 3 => 6
   }
   // selectedQuotient is in in OneHot encoding
-  // the first 2bits is unused in Truncate y
   val selectedQuotientOH: UInt =
     QDS(rWidth, ohWidth, dTruncateWidth - 1, tables, a)(
       leftShift(partialReminderSum, radixLog2).head(rWidth),
@@ -118,10 +117,8 @@ class SRT4(
       // if q is positive, add one to partialReminderCarry in the least bit
       val qdsSign = selectedQuotientOH(ohWidth - 1, ohWidth / 2 + 1).orR
 
-      /** todo why shift here? partialReminderSum is already rW[J] */
       addition.csa.c32(
         VecInit(
-          // todo: xLen -2 is enough, (xLen - 3, 2)
           leftShift(partialReminderSum, radixLog2).head(wLen - radixLog2),
           leftShift(partialReminderCarry, radixLog2).head(wLen - radixLog2 - 1) ## qdsSign,
           Mux1H(selectedQuotientOH, dividerMap)

--- a/arithmetic/src/division/srt/srt4/SRT4.scala
+++ b/arithmetic/src/division/srt/srt4/SRT4.scala
@@ -64,12 +64,12 @@ class SRT4(
 
   val occupiedNext = Wire(Bool())
   val occupied = RegNext(occupiedNext, false.B)
-  occupiedNext := Mux(input.fire, true.B, Mux(isLastCycle, false.B, occupied))
+  occupiedNext := input.fire || (!isLastCycle && occupied)
 
   //  Datapath
   //  according two adders
   isLastCycle := !counter.orR
-  output.valid := Mux(occupied, isLastCycle, false.B)
+  output.valid := occupied && isLastCycle
   input.ready := !occupied
   enable := input.fire || !isLastCycle
 

--- a/arithmetic/src/division/srt/srt4/SRT4.scala
+++ b/arithmetic/src/division/srt/srt4/SRT4.scala
@@ -34,7 +34,7 @@ class SRT4(
   dTruncateWidth: Int = 4,
   rTruncateWidth: Int = 4)
     extends Module {
-  val fixWidth = 2
+  val fixWidth = 1
   val divisorWidthFix = dividerWidth + fixWidth
 
   /** width for csa */
@@ -43,6 +43,7 @@ class SRT4(
   // IO
   val input = IO(Flipped(DecoupledIO(new SRTInput(dividendWidth, dividerWidth, n))))
   val output = IO(ValidIO(new SRTOutput(dividerWidth, dividendWidth)))
+  val dividendAppend = IO(Input(UInt(1.W)))
 
   //rW[j]
   val partialReminderCarryNext, partialReminderSumNext = Wire(UInt(wLen.W))
@@ -93,6 +94,7 @@ class SRT4(
     case 3 => 6
   }
   // selectedQuotient is in in OneHot encoding
+  // the first 2bits is unused in Truncate y
   val selectedQuotientOH: UInt =
     QDS(rWidth, ohWidth, dTruncateWidth - 1, tables, a)(
       leftShift(partialReminderSum, radixLog2).head(rWidth),
@@ -162,6 +164,6 @@ class SRT4(
   counterNext := Mux(input.fire, input.bits.counter, counter - 1.U)
   quotientNext := Mux(input.fire, 0.U, otf(0))
   quotientMinusOneNext := Mux(input.fire, 0.U, otf(1))
-  partialReminderSumNext := Mux(input.fire, Cat(input.bits.dividend, 1.U(fixWidth.W)), csa(1) << radixLog2)
+  partialReminderSumNext := Mux(input.fire, Cat(input.bits.dividend, dividendAppend), csa(1) << radixLog2)
   partialReminderCarryNext := Mux(input.fire, 0.U, csa(0) << 1 + radixLog2)
 }

--- a/arithmetic/src/division/srt/srt4/SRT4.scala
+++ b/arithmetic/src/division/srt/srt4/SRT4.scala
@@ -34,11 +34,11 @@ class SRT4(
   dTruncateWidth: Int = 4,
   rTruncateWidth: Int = 4)
     extends Module {
-  val fixWidth = 1
-  val divisorWidthFix = dividerWidth + fixWidth
+  val guardBitWidth = 1
+  val divisorWidthFix = dividerWidth + guardBitWidth
 
   /** width for csa */
-  val xLen: Int = dividendWidth + radixLog2 + 1 + fixWidth
+  val xLen: Int = dividendWidth + radixLog2 + 1 + guardBitWidth
   val wLen: Int = xLen + radixLog2
   // IO
   val input = IO(Flipped(DecoupledIO(new SRTInput(dividendWidth, dividerWidth, n, 2))))
@@ -80,7 +80,7 @@ class SRT4(
     partialReminderSum + partialReminderCarry + (divider << radixLog2)
   val needCorrect: Bool = remainderNoCorrect(wLen - 3).asBool
 
-  output.bits.reminder := Mux(needCorrect, remainderCorrect, remainderNoCorrect)(wLen - 4, radixLog2 + fixWidth)
+  output.bits.reminder := Mux(needCorrect, remainderCorrect, remainderNoCorrect)(wLen - 4, radixLog2 + guardBitWidth)
   output.bits.quotient := Mux(needCorrect, quotientMinusOne, quotient)
 
   /** 7 bits for truncated y */
@@ -156,7 +156,7 @@ class SRT4(
       )
     }
 
-  dividerNext := Mux(input.fire, Cat(input.bits.divider, 0.U(fixWidth.W)), divider)
+  dividerNext := Mux(input.fire, Cat(input.bits.divider, 0.U(guardBitWidth.W)), divider)
   counterNext := Mux(input.fire, input.bits.counter, counter - 1.U)
   quotientNext := Mux(input.fire, 0.U, otf(0))
   quotientMinusOneNext := Mux(input.fire, 0.U, otf(1))

--- a/arithmetic/src/division/srt/srt8/SRT8.scala
+++ b/arithmetic/src/division/srt/srt8/SRT8.scala
@@ -1,6 +1,5 @@
 package division.srt.srt8
 
-import Chisel.Cat
 import division.srt._
 import division.srt.SRTTable
 import chisel3._

--- a/arithmetic/src/division/srt/srt8/SRT8.scala
+++ b/arithmetic/src/division/srt/srt8/SRT8.scala
@@ -35,7 +35,11 @@ class SRT8(
   // IO
   val input = IO(Flipped(DecoupledIO(new SRTInput(dividendWidth, dividerWidth, n))))
   val output = IO(ValidIO(new SRTOutput(dividerWidth, dividendWidth)))
-  val fixValue = IO(Input(UInt(fixWidth.W)))
+  val dividendAppend = IO(Input(UInt(fixWidth.W)))
+  val appendWidth = IO(Input(UInt(2.W)))
+
+  val appendValue = Wire(UInt(2.W))
+  appendValue := Mux(appendWidth === 1.U, Cat(dividendAppend(0), 0.U(1.W)), dividendAppend)
 
   val partialReminderCarryNext, partialReminderSumNext = Wire(UInt(wLen.W))
   val quotientNext, quotientMinusOneNext = Wire(UInt(n.W))
@@ -128,7 +132,7 @@ class SRT8(
         Mux1H(qLow, dividerLMap)
       )
     )
-    partialReminderSumNext := Mux(input.fire, Cat(input.bits.dividend, fixValue), csa1(1) << radixLog2)
+    partialReminderSumNext := Mux(input.fire, Cat(input.bits.dividend, appendValue), csa1(1) << radixLog2)
     partialReminderCarryNext := Mux(input.fire, 0.U, csa1(0) << 1 + radixLog2)
   } else if (a == 6) {
     val qHigh:    UInt = selectedQuotientOH(7, 5)
@@ -156,7 +160,7 @@ class SRT8(
         Mux1H(qLow, dividerLMap)
       )
     )
-    partialReminderSumNext := Mux(input.fire, Cat(input.bits.dividend, fixValue), csa1(1) << radixLog2)
+    partialReminderSumNext := Mux(input.fire, Cat(input.bits.dividend, appendValue), csa1(1) << radixLog2)
     partialReminderCarryNext := Mux(input.fire, 0.U, csa1(0) << 1 + radixLog2)
   } else if (a == 5) {
     val qHigh:    UInt = selectedQuotientOH(7, 5)
@@ -184,7 +188,7 @@ class SRT8(
         Mux1H(qLow, dividerLMap)
       )
     )
-    partialReminderSumNext := Mux(input.fire, Cat(input.bits.dividend, fixValue), csa1(1) << radixLog2)
+    partialReminderSumNext := Mux(input.fire, Cat(input.bits.dividend, appendValue), csa1(1) << radixLog2)
     partialReminderCarryNext := Mux(input.fire, 0.U, csa1(0) << 1 + radixLog2)
   } else if (a == 4) {
     val qHigh:    UInt = selectedQuotientOH(7, 5)
@@ -212,7 +216,7 @@ class SRT8(
         Mux1H(qLow, dividerLMap)
       )
     )
-    partialReminderSumNext := Mux(input.fire, Cat(input.bits.dividend, fixValue), csa1(1) << radixLog2)
+    partialReminderSumNext := Mux(input.fire, Cat(input.bits.dividend, appendValue), csa1(1) << radixLog2)
     partialReminderCarryNext := Mux(input.fire, 0.U, csa1(0) << 1 + radixLog2)
   }
 

--- a/arithmetic/src/division/srt/srt8/SRT8.scala
+++ b/arithmetic/src/division/srt/srt8/SRT8.scala
@@ -56,12 +56,12 @@ class SRT8(
 
   val occupiedNext = Wire(Bool())
   val occupied = RegNext(occupiedNext, false.B)
-  occupiedNext := Mux(input.fire, true.B, Mux(isLastCycle, false.B, occupied))
+  occupiedNext := input.fire || (!isLastCycle && occupied)
 
   //  Datapath
   //  according two adders
   isLastCycle := !counter.orR
-  output.valid := Mux(occupied, isLastCycle, false.B)
+  output.valid := occupied && isLastCycle
   input.ready := !occupied
   enable := input.fire || !isLastCycle
 

--- a/arithmetic/src/division/srt/srt8/SRT8.scala
+++ b/arithmetic/src/division/srt/srt8/SRT8.scala
@@ -27,9 +27,9 @@ class SRT8(
   rTruncateWidth: Int = 4)
     extends Module {
 
-  val fixWidth = 2
-  val divisorWidthFix = dividerWidth + fixWidth
-  val xLen: Int = dividendWidth + radixLog2 + 1 + fixWidth
+  val guardBitWidth = 2
+  val divisorWidthFix = dividerWidth + guardBitWidth
+  val xLen: Int = dividendWidth + radixLog2 + 1 + guardBitWidth
   val wLen: Int = xLen + radixLog2
 
   // IO
@@ -70,7 +70,7 @@ class SRT8(
   val remainderCorrect: UInt =
     partialReminderSum + partialReminderCarry + (divider << radixLog2)
   val needCorrect: Bool = remainderNoCorrect(wLen - 4).asBool
-  output.bits.reminder := Mux(needCorrect, remainderCorrect, remainderNoCorrect)(wLen - 5, radixLog2 + fixWidth)
+  output.bits.reminder := Mux(needCorrect, remainderCorrect, remainderNoCorrect)(wLen - 5, radixLog2 + guardBitWidth)
   output.bits.quotient := Mux(needCorrect, quotientMinusOne, quotient)
 
   val rWidth: Int = 1 + radixLog2 + rTruncateWidth
@@ -215,7 +215,7 @@ class SRT8(
     partialReminderCarryNext := Mux(input.fire, 0.U, csa1(0) << 1 + radixLog2)
   }
 
-  dividerNext := Mux(input.fire, Cat(input.bits.divider, 0.U(fixWidth.W)), divider)
+  dividerNext := Mux(input.fire, Cat(input.bits.divider, 0.U(guardBitWidth.W)), divider)
   counterNext := Mux(input.fire, input.bits.counter, counter - 1.U)
   quotientNext := Mux(input.fire, 0.U, otf(0))
   quotientMinusOneNext := Mux(input.fire, 0.U, otf(1))

--- a/arithmetic/src/division/srt/srt8/SRT8.scala
+++ b/arithmetic/src/division/srt/srt8/SRT8.scala
@@ -33,13 +33,8 @@ class SRT8(
   val wLen: Int = xLen + radixLog2
 
   // IO
-  val input = IO(Flipped(DecoupledIO(new SRTInput(dividendWidth, dividerWidth, n))))
+  val input = IO(Flipped(DecoupledIO(new SRTInput(dividendWidth, dividerWidth, n, 3))))
   val output = IO(ValidIO(new SRTOutput(dividerWidth, dividendWidth)))
-  val dividendAppend = IO(Input(UInt(fixWidth.W)))
-  val appendWidth = IO(Input(UInt(2.W)))
-
-  val appendValue = Wire(UInt(2.W))
-  appendValue := Mux(appendWidth === 1.U, Cat(dividendAppend(0), 0.U(1.W)), dividendAppend)
 
   val partialReminderCarryNext, partialReminderSumNext = Wire(UInt(wLen.W))
   val quotientNext, quotientMinusOneNext = Wire(UInt(n.W))
@@ -132,7 +127,7 @@ class SRT8(
         Mux1H(qLow, dividerLMap)
       )
     )
-    partialReminderSumNext := Mux(input.fire, Cat(input.bits.dividend, appendValue), csa1(1) << radixLog2)
+    partialReminderSumNext := Mux(input.fire, input.bits.dividend, csa1(1) << radixLog2)
     partialReminderCarryNext := Mux(input.fire, 0.U, csa1(0) << 1 + radixLog2)
   } else if (a == 6) {
     val qHigh:    UInt = selectedQuotientOH(7, 5)
@@ -160,7 +155,7 @@ class SRT8(
         Mux1H(qLow, dividerLMap)
       )
     )
-    partialReminderSumNext := Mux(input.fire, Cat(input.bits.dividend, appendValue), csa1(1) << radixLog2)
+    partialReminderSumNext := Mux(input.fire, input.bits.dividend, csa1(1) << radixLog2)
     partialReminderCarryNext := Mux(input.fire, 0.U, csa1(0) << 1 + radixLog2)
   } else if (a == 5) {
     val qHigh:    UInt = selectedQuotientOH(7, 5)
@@ -188,7 +183,7 @@ class SRT8(
         Mux1H(qLow, dividerLMap)
       )
     )
-    partialReminderSumNext := Mux(input.fire, Cat(input.bits.dividend, appendValue), csa1(1) << radixLog2)
+    partialReminderSumNext := Mux(input.fire, input.bits.dividend, csa1(1) << radixLog2)
     partialReminderCarryNext := Mux(input.fire, 0.U, csa1(0) << 1 + radixLog2)
   } else if (a == 4) {
     val qHigh:    UInt = selectedQuotientOH(7, 5)
@@ -216,7 +211,7 @@ class SRT8(
         Mux1H(qLow, dividerLMap)
       )
     )
-    partialReminderSumNext := Mux(input.fire, Cat(input.bits.dividend, appendValue), csa1(1) << radixLog2)
+    partialReminderSumNext := Mux(input.fire, input.bits.dividend, csa1(1) << radixLog2)
     partialReminderCarryNext := Mux(input.fire, 0.U, csa1(0) << 1 + radixLog2)
   }
 

--- a/arithmetic/tests/src/division/srt/SRT16Test.scala
+++ b/arithmetic/tests/src/division/srt/SRT16Test.scala
@@ -9,17 +9,17 @@ import scala.util.Random
 object SRT16Test extends TestSuite with ChiselUtestTester {
   def tests: Tests = Tests {
     test("SRT16 should pass") {
-      def testcase(width: Int): Unit ={
+      def testcase(width: Int): Unit = {
         // parameters
         val radixLog2: Int = 4
-        val n: Int = width
-        val m: Int = n - 1
-        val p: Int = Random.nextInt(m - radixLog2 +1) //order to offer guardwidth
-        val q: Int = Random.nextInt(m - radixLog2 +1)
-        val dividend: BigInt = BigInt(p, Random)
-        val divider: BigInt = BigInt(q, Random)
-//        val dividend: BigInt = BigInt("65")
-//        val divider: BigInt = BigInt("1")
+        val n:         Int = width
+        val m:         Int = n - 1
+        val p:         Int = Random.nextInt(m - radixLog2 + 1) //order to offer guardwidth
+        val q:         Int = Random.nextInt(m - radixLog2 + 1)
+        val dividend:  BigInt = BigInt(p, Random)
+        val divider:   BigInt = BigInt(q, Random)
+//        val dividend: BigInt = 0x7fffffff
+//        val divider: BigInt = 16
         def zeroCheck(x: BigInt): Int = {
           var flag = false
           var a: Int = m
@@ -29,50 +29,53 @@ object SRT16Test extends TestSuite with ChiselUtestTester {
           }
           a + 1
         }
-        val zeroHeadDividend: Int = m - zeroCheck(dividend)
-        val zeroHeadDivider: Int = m - zeroCheck(divider)
+        val zeroHeadDividend:  Int = m - zeroCheck(dividend)
+        val zeroHeadDivider:   Int = m - zeroCheck(divider)
         val needComputerWidth: Int = zeroHeadDivider - zeroHeadDividend + 1 + 1
-        val noguard: Boolean =  needComputerWidth % radixLog2 == 0
-        val guardWidth: Int =  if (noguard) 0 else 4 - needComputerWidth % 4
-        val counter: Int = (needComputerWidth + guardWidth) / radixLog2
+        val noguard:           Boolean = needComputerWidth % radixLog2 == 0
+        val guardWidth:        Int = if (noguard) 0 else 4 - needComputerWidth % 4
+        val counter:           Int = (needComputerWidth + guardWidth) / radixLog2
         if ((divider == 0) || (divider > dividend) || (needComputerWidth <= 0))
           return
-        val quotient: BigInt = dividend / divider
-        val remainder: BigInt = dividend % divider
+        val quotient:               BigInt = dividend / divider
+        val remainder:              BigInt = dividend % divider
         val leftShiftWidthDividend: Int = zeroHeadDividend - guardWidth
-        val leftShiftWidthDivider: Int = zeroHeadDivider
+        val leftShiftWidthDivider:  Int = zeroHeadDivider
+
+//        println("leftShiftWidthDividend  = %d ".format(leftShiftWidthDividend))
         // test
-        testCircuit(new SRT16(n, n, n),
-          Seq(chiseltest.internal.NoThreadingAnnotation,
-            chiseltest.simulator.WriteVcdAnnotation)) {
-          dut: SRT16 =>
-            dut.clock.setTimeout(0)
-            dut.input.valid.poke(true.B)
-            dut.input.bits.dividend.poke((dividend << leftShiftWidthDividend).U)
-            dut.input.bits.divider.poke((divider << leftShiftWidthDivider).U)
-            dut.input.bits.counter.poke(counter.U)
-            dut.clock.step()
-            dut.input.valid.poke(false.B)
-            var flag = false
-            for (a <- 1 to 1000 if !flag) {
-              if (dut.output.valid.peek().litValue == 1) {
-                flag = true
-                println(dut.output.bits.quotient.peek().litValue)
-                println(dut.output.bits.reminder.peek().litValue)
-                utest.assert(dut.output.bits.quotient.peek().litValue == quotient)
-                utest.assert(dut.output.bits.reminder.peek().litValue >> zeroHeadDivider == remainder)
-              }
-              dut.clock.step()
+        testCircuit(
+          new SRT16(n, n, n),
+          Seq(chiseltest.internal.NoThreadingAnnotation, chiseltest.simulator.WriteVcdAnnotation)
+        ) { dut: SRT16 =>
+          dut.clock.setTimeout(0)
+          dut.input.valid.poke(true.B)
+          dut.input.bits.dividend.poke((dividend << leftShiftWidthDividend).U)
+          dut.input.bits.divider.poke((divider << leftShiftWidthDivider).U)
+          dut.input.bits.counter.poke(counter.U)
+          dut.fixValue.poke((dividend % 8).U)
+          dut.clock.step()
+          dut.input.valid.poke(false.B)
+          var flag = false
+          for (a <- 1 to 1000 if !flag) {
+            if (dut.output.valid.peek().litValue == 1) {
+              flag = true
+//                println(dut.output.bits.quotient.peek().litValue)
+//                println(dut.output.bits.reminder.peek().litValue)
+              utest.assert(dut.output.bits.quotient.peek().litValue == quotient)
+              utest.assert(dut.output.bits.reminder.peek().litValue >> zeroHeadDivider == remainder)
             }
-            utest.assert(flag)
-            dut.clock.step(scala.util.Random.nextInt(10))
+            dut.clock.step()
+          }
+          utest.assert(flag)
+          dut.clock.step(scala.util.Random.nextInt(10))
         }
       }
 
-      testcase(64)
-//      for( i <- 1 to 50){
-//        testcase(64)
-//      }
+      //     testcase(64)
+      for (i <- 1 to 30) {
+        testcase(64)
+      }
     }
   }
 }

--- a/arithmetic/tests/src/division/srt/SRT16Test.scala
+++ b/arithmetic/tests/src/division/srt/SRT16Test.scala
@@ -82,7 +82,11 @@ object SRT16Test extends TestSuite with ChiselUtestTester {
               }
 
               def check = {
-                if ((dut.output.bits.quotient.peek().litValue == quotient)||(dut.output.bits.reminder.peek().litValue >> zeroHeadDivisor == remainder)) {} else {
+                if (
+                  (dut.output.bits.quotient
+                    .peek()
+                    .litValue == quotient) || (dut.output.bits.reminder.peek().litValue >> zeroHeadDivisor == remainder)
+                ) {} else {
                   printvalue
                 }
               }

--- a/arithmetic/tests/src/division/srt/SRT16Test.scala
+++ b/arithmetic/tests/src/division/srt/SRT16Test.scala
@@ -16,10 +16,10 @@ object SRT16Test extends TestSuite with ChiselUtestTester {
         val m:         Int = n - 1
         val p:         Int = Random.nextInt(m - radixLog2 + 1) //order to offer guardwidth
         val q:         Int = Random.nextInt(m - radixLog2 + 1)
-        val dividend:  BigInt = BigInt(p, Random)
-        val divisor:   BigInt = BigInt(q, Random)
+
 //        val dividend: BigInt = BigInt("fffffff0",16) + x
-//        val divisor:  BigInt = BigInt(q, Random)
+        val dividend: BigInt = x
+        val divisor:  BigInt = d
         def zeroCheck(x: BigInt): Int = {
           var flag = false
           var a: Int = m
@@ -39,7 +39,7 @@ object SRT16Test extends TestSuite with ChiselUtestTester {
           return
         val quotient:               BigInt = dividend / divisor
         val remainder:              BigInt = dividend % divisor
-        val leftShiftWidthDividend: Int = zeroHeadDividend - guardWidth
+        val leftShiftWidthDividend: Int = zeroHeadDividend - guardWidth + 3
         val leftShiftWidthDivider:  Int = zeroHeadDivisor
 
         val dividendAppend = dividend % 8
@@ -57,8 +57,6 @@ object SRT16Test extends TestSuite with ChiselUtestTester {
           dut.input.bits.dividend.poke((dividend << leftShiftWidthDividend).U)
           dut.input.bits.divider.poke((divisor << leftShiftWidthDivider).U)
           dut.input.bits.counter.poke(counter.U)
-          dut.dividendAppend.poke(dividendAppend.U)
-          dut.appendWidth.poke(appendWidth.U)
           dut.clock.step()
           dut.input.valid.poke(false.B)
           var flag = false
@@ -67,6 +65,7 @@ object SRT16Test extends TestSuite with ChiselUtestTester {
               flag = true
 
               def printvalue(): Unit = {
+                println("SRT16 error!")
                 println("leftShiftWidthDividend  = %d ".format(leftShiftWidthDividend))
                 println("appendWidth  = %d ".format(appendWidth))
                 println("dividendAppend  = %d ".format(dividendAppend))
@@ -80,7 +79,6 @@ object SRT16Test extends TestSuite with ChiselUtestTester {
                   )
                 )
               }
-
               def check = {
                 if (
                   (dut.output.bits.quotient
@@ -90,7 +88,6 @@ object SRT16Test extends TestSuite with ChiselUtestTester {
                   printvalue
                 }
               }
-
               check
               utest.assert(dut.output.bits.quotient.peek().litValue == quotient)
               utest.assert(dut.output.bits.reminder.peek().litValue >> zeroHeadDivisor == remainder)
@@ -102,14 +99,16 @@ object SRT16Test extends TestSuite with ChiselUtestTester {
         }
       }
 
-//      for (i <- 16 to 31) {
-//        for (j <- 2 to i - 1) {
-//          testcase(5, i, j)
+//      for (i <- 0 to 15) {
+//        for (j <- 1 to 16) {
+//          testcase(32, i, j)
 //        }
 //      }
 
-      for (i <- 1 to 20) {
-        testcase(64, 0, 0)
+      for (i <- 2 to 31) {
+        for (j <- 1 to i - 1) {
+          testcase(5, i, j)
+        }
       }
 
     }

--- a/arithmetic/tests/src/division/srt/SRT4Test.scala
+++ b/arithmetic/tests/src/division/srt/SRT4Test.scala
@@ -8,17 +8,15 @@ import scala.util.{Random}
 object SRT4Test extends TestSuite with ChiselUtestTester {
   def tests: Tests = Tests {
     test("SRT4 should pass") {
-      def testcase(width: Int): Unit ={
+      def testcase(width: Int): Unit = {
         // parameters
         val radixLog2: Int = 2
-        val n: Int = width
-        val m: Int = n - 1
-        val p: Int = Random.nextInt(m)
-        val q: Int = Random.nextInt(m)
-        val dividend: BigInt = BigInt(p, Random)
-        val divider: BigInt = BigInt(q, Random)
-//        val dividend: BigInt = BigInt("65")
-//        val divider: BigInt = BigInt("1")
+        val n:         Int = width
+        val m:         Int = n - 1
+        val p:         Int = Random.nextInt(m)
+        val q:         Int = Random.nextInt(m)
+        val dividend:  BigInt = BigInt(p, Random)
+        val divisor:   BigInt = BigInt(q, Random)
         def zeroCheck(x: BigInt): Int = {
           var flag = false
           var a: Int = m
@@ -28,55 +26,63 @@ object SRT4Test extends TestSuite with ChiselUtestTester {
           }
           a + 1
         }
-        val zeroHeadDividend: Int = m - zeroCheck(dividend)
-        val zeroHeadDivider: Int = m - zeroCheck(divider)
-        val needComputerWidth: Int = zeroHeadDivider - zeroHeadDividend + 1 + radixLog2 - 1
-        val noguard: Boolean = needComputerWidth % radixLog2 == 0
-        val counter: Int = (needComputerWidth + 1) / 2
-        if ((divider == 0) || (divider > dividend) || (needComputerWidth <= 0))
+        val zeroHeadDividend:  Int = m - zeroCheck(dividend)
+        val zeroHeaddivisor:   Int = m - zeroCheck(divisor)
+        val needComputerWidth: Int = zeroHeaddivisor - zeroHeadDividend + 1 + radixLog2 - 1
+        val noguard:           Boolean = needComputerWidth % radixLog2 == 0
+        val guardWidth:        Int = if (noguard) 0 else 2 - needComputerWidth % 2
+        val counter:           Int = (needComputerWidth + 1) / 2
+        if ((divisor == 0) || (divisor > dividend) || (needComputerWidth <= 0))
           return
-        val quotient: BigInt = dividend / divider
-        val remainder: BigInt = dividend % divider
+        val quotient:               BigInt = dividend / divisor
+        val remainder:              BigInt = dividend % divisor
         val leftShiftWidthDividend: Int = zeroHeadDividend - (if (noguard) 0 else 1)
-        val leftShiftWidthDivider: Int = zeroHeadDivider
-//        println("dividend = %8x, dividend = %d ".format(dividend, dividend))
-//        println("divider  = %8x, divider  = %d".format(divider, divider))
-//        println("zeroHeadDividend  = %d,  dividend << zeroHeadDividend = %d".format(zeroHeadDividend, dividend << leftShiftWidthDividend))
-//        println("zeroHeadDivider   = %d,  divider << zeroHeadDivider  = %d".format(zeroHeadDivider, divider << leftShiftWidthDivider))
-//        println("quotient   = %d,  remainder  = %d".format(quotient, remainder))
-//        println("counter   = %d, needComputerWidth = %d".format(counter, needComputerWidth))
+        val leftShiftWidthdivisor:  Int = zeroHeaddivisor
+        println("leftShiftWidthDividend  = %d ".format(leftShiftWidthDividend))
+        /*        println("zeroHeadDividend_ex   = %d".format(zeroHeadDividend))
+        println("zeroHeaddivisor_ex   = %d".format(zeroHeaddivisor))
+        println("noguard = "+ noguard)
+        println("quotient   = %d,  remainder  = %d".format(quotient, remainder))
+        println("counter_ex   = %d, needComputerWidth_ex = %d".format(counter, needComputerWidth))*/
         // test
-        testCircuit(new SRT4(n, n, n),
-          Seq(chiseltest.internal.NoThreadingAnnotation,
-            chiseltest.simulator.WriteVcdAnnotation)) {
-          dut: SRT4 =>
-            dut.clock.setTimeout(0)
-            dut.input.valid.poke(true.B)
-            dut.input.bits.dividend.poke((dividend << leftShiftWidthDividend).U)
-            dut.input.bits.divider.poke((divider << leftShiftWidthDivider).U)
-            dut.input.bits.counter.poke(counter.U)
-            dut.clock.step()
-            dut.input.valid.poke(false.B)
-            var flag = false
-            for (a <- 1 to 1000 if !flag) {
-              if (dut.output.valid.peek().litValue == 1) {
-                flag = true
-                println(dut.output.bits.quotient.peek().litValue)
-                println(dut.output.bits.reminder.peek().litValue)
-                utest.assert(dut.output.bits.quotient.peek().litValue == quotient)
-                utest.assert(dut.output.bits.reminder.peek().litValue >> zeroHeadDivider == remainder)
-              }
-              dut.clock.step()
+        testCircuit(
+          new SRT4(n, n, n),
+          Seq(chiseltest.internal.NoThreadingAnnotation, chiseltest.simulator.WriteVcdAnnotation)
+        ) { dut: SRT4 =>
+          dut.clock.setTimeout(0)
+          dut.input.valid.poke(true.B)
+          dut.input.bits.dividend.poke((dividend << leftShiftWidthDividend).U)
+          dut.input.bits.divider.poke((divisor << leftShiftWidthdivisor).U)
+          dut.input.bits.counter.poke(counter.U)
+          dut.clock.step()
+          dut.input.valid.poke(false.B)
+          var flag = false
+          for (a <- 1 to 1000 if !flag) {
+            if (dut.output.valid.peek().litValue == 1) {
+              flag = true
+//              println("%x / %x = %x --- %x".format(dividend, divisor, quotient, remainder))
+//              println(
+//                "%x / %x = %x --- %x".format(
+//                  dividend,
+//                  divisor,
+//                  dut.output.bits.quotient.peek().litValue,
+//                  dut.output.bits.reminder.peek().litValue >> zeroHeaddivisor
+//                )
+//              )
+              utest.assert(dut.output.bits.quotient.peek().litValue == quotient)
+              utest.assert(dut.output.bits.reminder.peek().litValue >> zeroHeaddivisor == remainder)
             }
-            utest.assert(flag)
-            dut.clock.step(scala.util.Random.nextInt(10))
+            dut.clock.step()
+          }
+          utest.assert(flag)
+          dut.clock.step(scala.util.Random.nextInt(10))
         }
       }
 
-      testcase(64)
-//      for( i <- 1 to 50){
-//        testcase(64)
-//      }
+//      testcase(64)
+      for( i <- 1 to 30){
+        testcase(64)
+      }
     }
   }
 }

--- a/arithmetic/tests/src/division/srt/SRT4Test.scala
+++ b/arithmetic/tests/src/division/srt/SRT4Test.scala
@@ -77,7 +77,11 @@ object SRT4Test extends TestSuite with ChiselUtestTester {
               }
 
               def check = {
-                if ((dut.output.bits.quotient.peek().litValue == quotient) || (dut.output.bits.reminder.peek().litValue >> zeroHeaddivisor == remainder)) {} else {
+                if (
+                  (dut.output.bits.quotient
+                    .peek()
+                    .litValue == quotient) || (dut.output.bits.reminder.peek().litValue >> zeroHeaddivisor == remainder)
+                ) {} else {
                   printvalue
                 }
               }
@@ -99,8 +103,8 @@ object SRT4Test extends TestSuite with ChiselUtestTester {
 //        }
 //      }
 
-      for(i<-1 to 20){
-        testcase(64,0,0)
+      for (i <- 1 to 20) {
+        testcase(64, 0, 0)
       }
 
     }

--- a/arithmetic/tests/src/division/srt/SRT4Test.scala
+++ b/arithmetic/tests/src/division/srt/SRT4Test.scala
@@ -15,10 +15,9 @@ object SRT4Test extends TestSuite with ChiselUtestTester {
         val m:         Int = n - 1
         val p:         Int = Random.nextInt(m)
         val q:         Int = Random.nextInt(m)
-        val dividend:  BigInt = BigInt(p, Random)
-        val divisor:   BigInt = BigInt(q, Random)
-//        val dividend: BigInt = x
-//        val divisor:  BigInt = d
+//        val dividend: BigInt = BigInt("fffffff0", 16) + x
+        val dividend: BigInt = x
+        val divisor: BigInt = d
         def zeroCheck(x: BigInt): Int = {
           var flag = false
           var a: Int = m
@@ -38,7 +37,7 @@ object SRT4Test extends TestSuite with ChiselUtestTester {
           return
         val quotient:               BigInt = dividend / divisor
         val remainder:              BigInt = dividend % divisor
-        val leftShiftWidthDividend: Int = zeroHeadDividend - guardWidth
+        val leftShiftWidthDividend: Int = zeroHeadDividend - guardWidth + 1
         val leftShiftWidthdivisor:  Int = zeroHeaddivisor
 
         // test
@@ -51,7 +50,6 @@ object SRT4Test extends TestSuite with ChiselUtestTester {
           dut.input.bits.dividend.poke((dividend << leftShiftWidthDividend).U)
           dut.input.bits.divider.poke((divisor << leftShiftWidthdivisor).U)
           dut.input.bits.counter.poke(counter.U)
-          dut.dividendAppend.poke((dividend % 2).U)
           dut.clock.step()
           dut.input.valid.poke(false.B)
           var flag = false
@@ -60,6 +58,7 @@ object SRT4Test extends TestSuite with ChiselUtestTester {
               flag = true
 
               def printvalue(): Unit = {
+                println("SRT4 error!")
                 println("zeroHeadDividend_ex   = %d".format(zeroHeadDividend))
                 println("zeroHeaddivisor_ex   = %d".format(zeroHeaddivisor))
                 println("guardWidth = " + guardWidth)
@@ -85,7 +84,6 @@ object SRT4Test extends TestSuite with ChiselUtestTester {
                   printvalue
                 }
               }
-
               check
               utest.assert(dut.output.bits.quotient.peek().litValue == quotient)
               utest.assert(dut.output.bits.reminder.peek().litValue >> zeroHeaddivisor == remainder)
@@ -97,15 +95,17 @@ object SRT4Test extends TestSuite with ChiselUtestTester {
         }
       }
 
-//      for (i <- 128 to 255) {
-//        for (j <- 1 to i - 1) {
-//          testcase(8, i, j)
+//      for (i <- 0 to 15) {
+//        for (j <- 1 to 16) {
+//          testcase(32, i, j)
 //        }
 //      }
 
-      for (i <- 1 to 20) {
-        testcase(64, 0, 0)
-      }
+            for (i <- 2 to 15) {
+              for (j <- 1 to i-1) {
+                testcase(4, i, j)
+              }
+            }
 
     }
   }

--- a/arithmetic/tests/src/division/srt/SRT8Test.scala
+++ b/arithmetic/tests/src/division/srt/SRT8Test.scala
@@ -9,7 +9,7 @@ import scala.util.Random
 object SRT8Test extends TestSuite with ChiselUtestTester {
   def tests: Tests = Tests {
     test("SRT8 should pass") {
-      def testcase(width: Int): Unit = {
+      def testcase(width: Int, x: Int, d: Int): Unit = {
         // parameters
         val radixLog2: Int = 3
         val n:         Int = width
@@ -17,9 +17,9 @@ object SRT8Test extends TestSuite with ChiselUtestTester {
         val p:         Int = Random.nextInt(m - radixLog2 + 1) //order to offer guardwidth
         val q:         Int = Random.nextInt(m - radixLog2 + 1)
         val dividend:  BigInt = BigInt(p, Random)
-        val divider:   BigInt = BigInt(q, Random)
-//        val dividend: BigInt = 0x7fffffff
-//        val divider: BigInt = 8
+        val divisor:   BigInt = BigInt(q, Random)
+//        val dividend: BigInt = x
+//        val divisor: BigInt = d
         def zeroCheck(x: BigInt): Int = {
           var flag = false
           var a: Int = m
@@ -30,19 +30,23 @@ object SRT8Test extends TestSuite with ChiselUtestTester {
           a + 1
         }
         val zeroHeadDividend:  Int = m - zeroCheck(dividend)
-        val zeroHeadDivider:   Int = m - zeroCheck(divider)
-        val needComputerWidth: Int = zeroHeadDivider - zeroHeadDividend + 1 + radixLog2 - 1
+        val zeroHeadDivisor:   Int = m - zeroCheck(divisor)
+        val needComputerWidth: Int = zeroHeadDivisor - zeroHeadDividend + 1 + radixLog2 - 1
         val noguard:           Boolean = needComputerWidth % radixLog2 == 0
         val guardWidth:        Int = if (noguard) 0 else 3 - needComputerWidth % 3
         val counter:           Int = (needComputerWidth + guardWidth) / radixLog2
-        if ((divider == 0) || (divider > dividend) || (needComputerWidth <= 0))
+        if ((divisor == 0) || (divisor > dividend) || (needComputerWidth <= 0))
           return
-        val quotient:               BigInt = dividend / divider
-        val remainder:              BigInt = dividend % divider
+        val quotient:               BigInt = dividend / divisor
+        val remainder:              BigInt = dividend % divisor
         val leftShiftWidthDividend: Int = zeroHeadDividend - guardWidth
-        val leftShiftWidthDivider:  Int = zeroHeadDivider
+        val leftShiftWidthDivider:  Int = zeroHeadDivisor
 
-//        println("leftShiftWidthDividend  = %d ".format(leftShiftWidthDividend))
+        val dividendAppend = dividend % 4
+        val appendWidth = if (leftShiftWidthDividend < 0) {
+          -leftShiftWidthDividend
+        } else 0
+
         testCircuit(
           new SRT8(n, n, n),
           Seq(chiseltest.internal.NoThreadingAnnotation, chiseltest.simulator.WriteVcdAnnotation)
@@ -50,19 +54,41 @@ object SRT8Test extends TestSuite with ChiselUtestTester {
           dut.clock.setTimeout(0)
           dut.input.valid.poke(true.B)
           dut.input.bits.dividend.poke((dividend << leftShiftWidthDividend).U)
-          dut.input.bits.divider.poke((divider << leftShiftWidthDivider).U)
+          dut.input.bits.divider.poke((divisor << leftShiftWidthDivider).U)
           dut.input.bits.counter.poke(counter.U)
-          dut.fixValue.poke((dividend % 4).U)
+          dut.dividendAppend.poke(dividendAppend.U)
+          dut.appendWidth.poke(appendWidth.U)
           dut.clock.step()
           dut.input.valid.poke(false.B)
           var flag = false
           for (a <- 1 to 1000 if !flag) {
             if (dut.output.valid.peek().litValue == 1) {
               flag = true
-//              println(dut.output.bits.quotient.peek().litValue)
-//              println(dut.output.bits.reminder.peek().litValue)
+
+              //printvalue()
+
+              def printvalue(): Unit = {
+                println("leftShiftWidthDividend  = %d ".format(leftShiftWidthDividend))
+                println("%d / %d = %d --- %d".format(dividend, divisor, quotient, remainder))
+                println(
+                  "%d / %d = %d --- %d".format(
+                    dividend,
+                    divisor,
+                    dut.output.bits.quotient.peek().litValue,
+                    dut.output.bits.reminder.peek().litValue >> zeroHeadDivisor
+                  )
+                )
+              }
+
+              def check = {
+                if ((dut.output.bits.quotient.peek().litValue == quotient) || (dut.output.bits.reminder.peek().litValue >> zeroHeadDivisor == remainder)) {} else {
+                  printvalue
+                }
+              }
+
+              check
               utest.assert(dut.output.bits.quotient.peek().litValue == quotient)
-              utest.assert(dut.output.bits.reminder.peek().litValue >> zeroHeadDivider == remainder)
+              utest.assert(dut.output.bits.reminder.peek().litValue >> zeroHeadDivisor == remainder)
             }
             dut.clock.step()
           }
@@ -71,10 +97,16 @@ object SRT8Test extends TestSuite with ChiselUtestTester {
         }
       }
 
-      //     testcase(64)
-      for (i <- 1 to 30) {
-        testcase(64)
+//      for (i <- 2 to 255) {
+//        for (j <- 1 to i - 1) {
+//          testcase(8, i, j)
+//        }
+//      }
+
+      for (i <- 1 to 20) {
+        testcase(64, 0, 0)
       }
+
     }
   }
 }

--- a/arithmetic/tests/src/division/srt/SRT8Test.scala
+++ b/arithmetic/tests/src/division/srt/SRT8Test.scala
@@ -9,17 +9,17 @@ import scala.util.Random
 object SRT8Test extends TestSuite with ChiselUtestTester {
   def tests: Tests = Tests {
     test("SRT8 should pass") {
-      def testcase(width: Int): Unit ={
+      def testcase(width: Int): Unit = {
         // parameters
         val radixLog2: Int = 3
-        val n: Int = width
-        val m: Int = n - 1
-        val p: Int = Random.nextInt(m - radixLog2 +1) //order to offer guardwidth
-        val q: Int = Random.nextInt(m - radixLog2 +1)
-        val dividend: BigInt = BigInt(p, Random)
-        val divider: BigInt = BigInt(q, Random)
-//        val dividend: BigInt = BigInt("65")
-//        val divider: BigInt = BigInt("1")
+        val n:         Int = width
+        val m:         Int = n - 1
+        val p:         Int = Random.nextInt(m - radixLog2 + 1) //order to offer guardwidth
+        val q:         Int = Random.nextInt(m - radixLog2 + 1)
+        val dividend:  BigInt = BigInt(p, Random)
+        val divider:   BigInt = BigInt(q, Random)
+//        val dividend: BigInt = 0x7fffffff
+//        val divider: BigInt = 8
         def zeroCheck(x: BigInt): Int = {
           var flag = false
           var a: Int = m
@@ -29,49 +29,52 @@ object SRT8Test extends TestSuite with ChiselUtestTester {
           }
           a + 1
         }
-        val zeroHeadDividend: Int = m - zeroCheck(dividend)
-        val zeroHeadDivider: Int = m - zeroCheck(divider)
-        val needComputerWidth: Int = zeroHeadDivider - zeroHeadDividend + 1 + radixLog2 -1
-        val noguard: Boolean =  needComputerWidth % radixLog2 == 0
-        val guardWidth: Int =  if (noguard) 0 else 3 - needComputerWidth % 3
-        val counter: Int = (needComputerWidth + guardWidth) / radixLog2
+        val zeroHeadDividend:  Int = m - zeroCheck(dividend)
+        val zeroHeadDivider:   Int = m - zeroCheck(divider)
+        val needComputerWidth: Int = zeroHeadDivider - zeroHeadDividend + 1 + radixLog2 - 1
+        val noguard:           Boolean = needComputerWidth % radixLog2 == 0
+        val guardWidth:        Int = if (noguard) 0 else 3 - needComputerWidth % 3
+        val counter:           Int = (needComputerWidth + guardWidth) / radixLog2
         if ((divider == 0) || (divider > dividend) || (needComputerWidth <= 0))
           return
-        val quotient: BigInt = dividend / divider
-        val remainder: BigInt = dividend % divider
+        val quotient:               BigInt = dividend / divider
+        val remainder:              BigInt = dividend % divider
         val leftShiftWidthDividend: Int = zeroHeadDividend - guardWidth
-        val leftShiftWidthDivider: Int = zeroHeadDivider
-        testCircuit(new SRT8(n, n, n),
-          Seq(chiseltest.internal.NoThreadingAnnotation,
-            chiseltest.simulator.WriteVcdAnnotation)) {
-          dut: SRT8 =>
-            dut.clock.setTimeout(0)
-            dut.input.valid.poke(true.B)
-            dut.input.bits.dividend.poke((dividend << leftShiftWidthDividend).U)
-            dut.input.bits.divider.poke((divider << leftShiftWidthDivider).U)
-            dut.input.bits.counter.poke(counter.U)
-            dut.clock.step()
-            dut.input.valid.poke(false.B)
-            var flag = false
-            for (a <- 1 to 1000 if !flag) {
-              if (dut.output.valid.peek().litValue == 1) {
-                flag = true
-                println(dut.output.bits.quotient.peek().litValue)
-                println(dut.output.bits.reminder.peek().litValue)
-                utest.assert(dut.output.bits.quotient.peek().litValue == quotient)
-                utest.assert(dut.output.bits.reminder.peek().litValue >> zeroHeadDivider == remainder)
-              }
-              dut.clock.step()
+        val leftShiftWidthDivider:  Int = zeroHeadDivider
+
+//        println("leftShiftWidthDividend  = %d ".format(leftShiftWidthDividend))
+        testCircuit(
+          new SRT8(n, n, n),
+          Seq(chiseltest.internal.NoThreadingAnnotation, chiseltest.simulator.WriteVcdAnnotation)
+        ) { dut: SRT8 =>
+          dut.clock.setTimeout(0)
+          dut.input.valid.poke(true.B)
+          dut.input.bits.dividend.poke((dividend << leftShiftWidthDividend).U)
+          dut.input.bits.divider.poke((divider << leftShiftWidthDivider).U)
+          dut.input.bits.counter.poke(counter.U)
+          dut.fixValue.poke((dividend % 4).U)
+          dut.clock.step()
+          dut.input.valid.poke(false.B)
+          var flag = false
+          for (a <- 1 to 1000 if !flag) {
+            if (dut.output.valid.peek().litValue == 1) {
+              flag = true
+//              println(dut.output.bits.quotient.peek().litValue)
+//              println(dut.output.bits.reminder.peek().litValue)
+              utest.assert(dut.output.bits.quotient.peek().litValue == quotient)
+              utest.assert(dut.output.bits.reminder.peek().litValue >> zeroHeadDivider == remainder)
             }
-            utest.assert(flag)
-            dut.clock.step(scala.util.Random.nextInt(10))
+            dut.clock.step()
+          }
+          utest.assert(flag)
+          dut.clock.step(scala.util.Random.nextInt(10))
         }
       }
 
-      testcase(64)
-//      for( i <- 1 to 50){
-//        testcase(64)
-//      }
+      //     testcase(64)
+      for (i <- 1 to 30) {
+        testcase(64)
+      }
     }
   }
 }

--- a/arithmetic/tests/src/division/srt/SRT8Test.scala
+++ b/arithmetic/tests/src/division/srt/SRT8Test.scala
@@ -16,10 +16,10 @@ object SRT8Test extends TestSuite with ChiselUtestTester {
         val m:         Int = n - 1
         val p:         Int = Random.nextInt(m - radixLog2 + 1) //order to offer guardwidth
         val q:         Int = Random.nextInt(m - radixLog2 + 1)
-        val dividend:  BigInt = BigInt(p, Random)
-        val divisor:   BigInt = BigInt(q, Random)
-//        val dividend: BigInt = x
-//        val divisor: BigInt = d
+
+//        val dividend: BigInt = BigInt("fffffff0", 16) + x
+        val dividend: BigInt = x
+        val divisor:  BigInt = d
         def zeroCheck(x: BigInt): Int = {
           var flag = false
           var a: Int = m
@@ -39,7 +39,7 @@ object SRT8Test extends TestSuite with ChiselUtestTester {
           return
         val quotient:               BigInt = dividend / divisor
         val remainder:              BigInt = dividend % divisor
-        val leftShiftWidthDividend: Int = zeroHeadDividend - guardWidth
+        val leftShiftWidthDividend: Int = zeroHeadDividend - guardWidth + 2
         val leftShiftWidthDivider:  Int = zeroHeadDivisor
 
         val dividendAppend = dividend % 4
@@ -56,8 +56,6 @@ object SRT8Test extends TestSuite with ChiselUtestTester {
           dut.input.bits.dividend.poke((dividend << leftShiftWidthDividend).U)
           dut.input.bits.divider.poke((divisor << leftShiftWidthDivider).U)
           dut.input.bits.counter.poke(counter.U)
-          dut.dividendAppend.poke(dividendAppend.U)
-          dut.appendWidth.poke(appendWidth.U)
           dut.clock.step()
           dut.input.valid.poke(false.B)
           var flag = false
@@ -65,9 +63,8 @@ object SRT8Test extends TestSuite with ChiselUtestTester {
             if (dut.output.valid.peek().litValue == 1) {
               flag = true
 
-              //printvalue()
-
               def printvalue(): Unit = {
+                println("SRT8 error!")
                 println("leftShiftWidthDividend  = %d ".format(leftShiftWidthDividend))
                 println("%d / %d = %d --- %d".format(dividend, divisor, quotient, remainder))
                 println(
@@ -81,11 +78,14 @@ object SRT8Test extends TestSuite with ChiselUtestTester {
               }
 
               def check = {
-                if ((dut.output.bits.quotient.peek().litValue == quotient) || (dut.output.bits.reminder.peek().litValue >> zeroHeadDivisor == remainder)) {} else {
+                if (
+                  (dut.output.bits.quotient
+                    .peek()
+                    .litValue == quotient) || (dut.output.bits.reminder.peek().litValue >> zeroHeadDivisor == remainder)
+                ) {} else {
                   printvalue
                 }
               }
-
               check
               utest.assert(dut.output.bits.quotient.peek().litValue == quotient)
               utest.assert(dut.output.bits.reminder.peek().litValue >> zeroHeadDivisor == remainder)
@@ -97,14 +97,16 @@ object SRT8Test extends TestSuite with ChiselUtestTester {
         }
       }
 
-//      for (i <- 2 to 255) {
-//        for (j <- 1 to i - 1) {
-//          testcase(8, i, j)
+//      for (i <- 0 to 15) {
+//        for (j <- 1 to 16) {
+//          testcase(32, i, j)
 //        }
 //      }
 
-      for (i <- 1 to 20) {
-        testcase(64, 0, 0)
+      for (i <- 2 to 15) {
+        for (j <- 1 to i - 1) {
+          testcase(4, i, j)
+        }
       }
 
     }

--- a/arithmetic/tests/src/division/srt/SRTTest.scala
+++ b/arithmetic/tests/src/division/srt/SRTTest.scala
@@ -80,9 +80,9 @@ object SRTTest extends TestSuite with ChiselUtestTester {
         }
       }
 //      testcase(64)
-      for( i <- 1 to 50){
-        testcase(n = 64, radixLog2 = 3, a = 7, dTruncateWidth = 4, rTruncateWidth = 4)
-      }
+//      for( i <- 1 to 50){
+//        testcase(n = 64, radixLog2 = 3, a = 7, dTruncateWidth = 4, rTruncateWidth = 4)
+//      }
     }
   }
 }


### PR DESCRIPTION
Bug happens when SRT dividend leftshiftWidth is negative(-1,-2 or -3). In this case, the SRT module will receive the residual[0] without it's last a few bits(1,2 or 3). In this case the SRT initialization is wrong.

The last a few bits should be  SRT input to fix this issue. And some corresponding bit width should be extended.

Now the srt.dividend IO is extended to (dividendWidth + guardWidthMax) bits to make sure all the dividend bits comes in.

As for the testbench, to test a small width SRT module with all the cases will work better.