### PR TITLE
fix Chisel deprecated APIs

### DIFF
--- a/arithmetic/src/addition/csa/CSACompressor.scala
+++ b/arithmetic/src/addition/csa/CSACompressor.scala
@@ -31,9 +31,7 @@ abstract class CSACompressor(val inputSize: Int, val outputSize: Int) {
 
   val encodeTable: Map[BigInt, Seq[BigInt]]
 
-  def decode(outputBits: UInt): UInt = util.MuxLookup(
-    outputBits,
-    0.U,
+  def decode(outputBits: UInt): UInt = util.MuxLookup(outputBits, 0.U)(
     decodeTable.map { case (k, v) => k.U -> v.U }.toSeq
   )
 

--- a/arithmetic/src/crypto/modmul/Barrett.scala
+++ b/arithmetic/src/crypto/modmul/Barrett.scala
@@ -1,7 +1,6 @@
 package crypto.modmul
 
 import chisel3._
-import chisel3.experimental.ChiselEnum
 import chisel3.util.experimental.decode.TruthTable
 import chisel3.util.{BitPat, Counter, Mux1H}
 

--- a/arithmetic/src/crypto/modmul/Montgomery.scala
+++ b/arithmetic/src/crypto/modmul/Montgomery.scala
@@ -1,7 +1,6 @@
 package crypto.modmul
 
 import chisel3._
-import chisel3.experimental.ChiselEnum
 import chisel3.util.experimental.decode.TruthTable
 import chisel3.util.{Counter, Mux1H}
 

--- a/arithmetic/src/multiplier/WallaceMultiplier.scala
+++ b/arithmetic/src/multiplier/WallaceMultiplier.scala
@@ -101,7 +101,7 @@ class WallaceMultiplierImpl(
   }
 
   def makePartialProducts(i: Int, recoded: SInt): Seq[(Int, Bool)] = { // Seq[(weight, value)]
-    val bb: UInt = MuxLookup(recoded.asUInt, 0.S(bMultipleWidth), partialProductLookupTable).asUInt
+    val bb: UInt = MuxLookup(recoded.asUInt, 0.S(bMultipleWidth))(partialProductLookupTable).asUInt
     val shouldPlus1 = recoded.head(1).asBool
     val s = if (signed) bb.head(1) else shouldPlus1
     val pp = i match {


### PR DESCRIPTION
Upstream Chisel deleted many old deprecated APIs in chipsalliance/chisel#3733, this PR fixes them to compile with the mainline Chisel.